### PR TITLE
Scene#exitの引数型を修正

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1248,6 +1248,7 @@ declare namespace phina {
         var Object2D: Object2DStatic
 
         interface Scene extends Element {
+            exit(nextArguments: { nextLabel?: string } & object): this
             exit(naxtLabel?: string, nextArguments?: object): this
         }
         interface SceneStatic {


### PR DESCRIPTION
Scene#exitは第一引数にnextLabelを持ったオブジェクトも渡せるため、オーバーロードを追加しました。